### PR TITLE
CASExport: add recursive Maple translation for nested commands

### DIFF
--- a/common/src/main/java/org/geogebra/common/export/CASExport.java
+++ b/common/src/main/java/org/geogebra/common/export/CASExport.java
@@ -323,65 +323,7 @@ public class CASExport {
 					if (ve != null) {
 						Command command = ve.getTopLevelCommand();
 						if (command != null) {
-							String name = command.getName();
-						
-		
-							switch (name) {
-							    case "Solve":
-								    def = MapleCommandTranslator.translateSolve(command);
-									break;
-							    case "Factor":
-									def = MapleCommandTranslator.translateFactor(command);
-									break;
-							    case "Derivative":
-									def = MapleCommandTranslator.translateDerivative(command, fullNameToShortName);
-									break;
-							    case "Eliminate":
-									def = MapleCommandTranslator.translateEliminate(command);
-									break;
-								case "Integral":
-									def = MapleCommandTranslator.translateIntegral(command,fullNameToShortName);
-									break;
-							    case "IntegralBetween":
-									def = MapleCommandTranslator.translateIntegralBetween(command,fullNameToShortName);
-									break;
-								case "Limit":
-									def = MapleCommandTranslator.translateLimit(command,fullNameToShortName);
-									break;
-								case "CurveCartesian":
-									def = MapleCommandTranslator.translateCurveCartesian(command,fullNameToShortName);
-									break;
-							    case "Degree":
-								    def = MapleCommandTranslator.translateDegree(command,fullNameToShortName);
-									break;
-							    case "Denominator":
-									def = MapleCommandTranslator.translateDenominator(command,fullNameToShortName);
-									break;
-								case "Invert":
-									def = MapleCommandTranslator.translateInvert(command);
-									break;
-								case "Numeric":
-									def = MapleCommandTranslator.translateNumeric(command,fullNameToShortName);
-									break;
-								case "Substitute":
-									def = MapleCommandTranslator.translateSubstitute(command, fullNameToShortName);
-									break;
-								case "IsPrime":
-									def = MapleCommandTranslator.translateIsPrime(command);
-									break;
-								case "ModularExponent":
-									def = MapleCommandTranslator.translateModularExponent(command);
-									break;
-								case "PrimeFactors":
-									def = MapleCommandTranslator.translatePrimeFactors(command);
-									break;
-								case "Laplace":
-									def = MapleCommandTranslator.translateLaplace(command);
-									break;
-								case "InverseLaplace":
-									def = MapleCommandTranslator.translateInverseLaplace(command);
-									break;
-							}
+							def = translateMapleCommand(command, fullNameToShortName);
 						}
 					}
 
@@ -394,10 +336,131 @@ public class CASExport {
 			}
 		}
 
-		// TODO: Consider putting this to somewhere else
-		txt = txt.replace("'", "_"); // always use _ instead of '
-
 		return txt;
+	}
+
+	private String translateMapleCommand(Command command,
+			Map<String, String> fullNameToShortName) {
+
+		String def = null;
+		String name = command.getName();
+
+		switch (name) {
+		case "AreEqual":
+			def = MapleCommandTranslator.translateAreEqual(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Solve":
+			def = MapleCommandTranslator.translateSolve(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Factor":
+			def = MapleCommandTranslator.translateFactor(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Derivative":
+			def = MapleCommandTranslator.translateDerivative(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Eliminate":
+			def = MapleCommandTranslator.translateEliminate(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Integral":
+			def = MapleCommandTranslator.translateIntegral(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "IntegralBetween":
+			def = MapleCommandTranslator.translateIntegralBetween(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Limit":
+			def = MapleCommandTranslator.translateLimit(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "CurveCartesian":
+			def = MapleCommandTranslator.translateCurveCartesian(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Degree":
+			def = MapleCommandTranslator.translateDegree(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Denominator":
+			def = MapleCommandTranslator.translateDenominator(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Invert":
+			def = MapleCommandTranslator.translateInvert(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Numeric":
+			def = MapleCommandTranslator.translateNumeric(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Substitute":
+			def = MapleCommandTranslator.translateSubstitute(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "IsPrime":
+			def = MapleCommandTranslator.translateIsPrime(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "ModularExponent":
+			def = MapleCommandTranslator.translateModularExponent(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "PrimeFactors":
+			def = MapleCommandTranslator.translatePrimeFactors(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "Laplace":
+			def = MapleCommandTranslator.translateLaplace(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+
+		case "InverseLaplace":
+			def = MapleCommandTranslator.translateInverseLaplace(command,
+					argument -> translateMapleArgument(argument, fullNameToShortName));
+			break;
+		}
+
+		return def;
+	}
+
+
+	private String translateMapleArgument(ExpressionNode argument,
+			Map<String, String> fullNameToShortName) {
+
+		Command nestedCommand = argument.getTopLevelCommand();
+
+		if (nestedCommand != null) {
+			return translateMapleCommand(nestedCommand, fullNameToShortName);
+		}
+
+		// TODO: handle equations whose left/right sides may contain nested commands
+		// Example: Solve(Derivative(x^2) = 0, x)
+		// The whole argument is not a command, but the left side is.
+
+		String expression = argument.getCASstring(StringTemplate.casCopyTemplate, false);
+		return MapleCommandTranslator.getMapleName(expression, fullNameToShortName);
 	}
 
 	public String createGiacTxt() {

--- a/common/src/main/java/org/geogebra/common/export/MapleCommandTranslator.java
+++ b/common/src/main/java/org/geogebra/common/export/MapleCommandTranslator.java
@@ -2,12 +2,14 @@ package org.geogebra.common.export;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.geogebra.common.kernel.StringTemplate;
 import org.geogebra.common.kernel.arithmetic.Command;
 import org.geogebra.common.kernel.arithmetic.ExpressionNode;
 import org.geogebra.common.kernel.arithmetic.SymbolicMode;
 import org.geogebra.common.kernel.geos.GeoElement;
+
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -17,11 +19,29 @@ final class MapleCommandTranslator {
 		// utility class
 	}
 
-	static String translateSolve(Command command) {
+	static String translateAreEqual(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+
+		int numOfArguments = command.getArgumentNumber();
+
+		// if there are two arguments then the command form is AreEqual( <Object>, <Object> )
+		if (numOfArguments == 2) {
+			String firstExpression = argumentTranslator.apply(command.getArgument(0));
+			String secondExpression = argumentTranslator.apply(command.getArgument(1));
+
+			return "evalb(simplify((" + firstExpression + ")-("
+					+ secondExpression + ")) = 0)";
+		}
+
+		return null;
+	}
+
+	static String translateSolve(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
 		if (numOfArguments == 2) {
-			String eqs = getArgumentOfCommand(command,0);
+			String eqs = argumentTranslator.apply(command.getArgument(0));
 			String vars = String.valueOf(command.getArgument(1));
 			vars = vars.replace("{", "[");
 			vars = vars.replace("}", "]");
@@ -31,29 +51,40 @@ final class MapleCommandTranslator {
 		return null;
 	}
 
-	// need to handle the cases of factor polynom
-	static String translateFactor(Command command) {
+	static String translateFactor(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
-		if (numOfArguments == 1) { // two numOfArguments are not implemented, TODO
-			// Maple does not have an option to have a second argument
+		// if there is one argument then the command form is Factor( <Polynomial> )
+		// or Factor( <Number> )
+		if (numOfArguments == 1) {
 			String expr = command.getArgument(0).toString();
 			if (expr.startsWith("$")) {
 				// This is something like $1, so we convert it into something like !1:
 				expr = "!" + expr.substring(1);
 			} else {
-				expr = getArgumentOfCommand(command,0);
+				expr = argumentTranslator.apply(command.getArgument(0));
 			}
-			return "ifactor(" + expr + ")";
+			if (isIntegerExpression(expr)) {
+				return "ifactor(" + expr + ")";
+			}
+			return "factor(" + expr + ")";
 		}
-
+		// if there are two arguments then the command form is Factor( <Expression>, <Variable> )
+		if (numOfArguments == 2) {
+			String expr = argumentTranslator.apply(command.getArgument(0));
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			return "factor(" + expr + "," + varName + ")";
+		}
 		return null;
+
 	}
 
-	static String translateDerivative(Command command, Map<String, String> fullNameToShortName) {
+	static String translateDerivative(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is Derivative( <Function> )
 		if (numOfArguments == 1) {
@@ -63,7 +94,7 @@ final class MapleCommandTranslator {
 		// if there are two arguments then the command form is either
 		// Derivative( <Function>, <Number> ) or Derivative( <Expression>, <Variable> )
 		if (numOfArguments == 2) {
-			String secondArg = getArgumentOfCommand(command, 1);
+			String secondArg = argumentTranslator.apply(command.getArgument(1));
 
 			// try to convert the second arg to number
 			// in case the command form is Derivative( <Function>, <Number> )
@@ -79,19 +110,20 @@ final class MapleCommandTranslator {
 
 		// if there are three arguments then the command form is Derivative( <Expression>, <Variable>, <Number> )
 		if (numOfArguments == 3) {
-			String varName = getArgumentOfCommand(command, 1);
-			String order = getArgumentOfCommand(command, 2);
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			String order = argumentTranslator.apply(command.getArgument(2));
 			return "diff(" + expression + "," + varName + "$" + order + ")";
 		}
 
 		return null;
 	}
 
-	static String translateEliminate(Command command) {
+	static String translateEliminate(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 		String vars = "[";
 		if (numOfArguments == 2) {
-			String eqs = getArgumentOfCommand(command, 0);
+			String eqs = argumentTranslator.apply(command.getArgument(0));
 			ExpressionNode equationsEN = command.getArgument(0);
 			ExpressionNode variablesEN = command.getArgument(1);
 			HashSet<GeoElement>
@@ -115,10 +147,14 @@ final class MapleCommandTranslator {
 		return null;
 	}
 
-	static String translateIntegral(Command command, Map<String, String> fullNameToShortName) {
+	// TODO: GeoGebra may add an integration constant for indefinite integrals,
+	// while Maple int(...) usually does not. This can affect nested commands,
+	// especially when the result is later used inside IntegralBetween.
+	static String translateIntegral(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is Integral( <Function> )
 		if (numOfArguments == 1) {
@@ -127,81 +163,84 @@ final class MapleCommandTranslator {
 
 		// if there are two arguments then the command form is Integral( <Function>, <Variable> )
 		if (numOfArguments == 2) {
-			String varName = getArgumentOfCommand(command, 1);
+			String varName = argumentTranslator.apply(command.getArgument(1));
 			return "int(" + expression + "," + varName + ")";
 		}
 
 		// if there are three arguments then the command form is Integral( <Function>, <Start x-Value>, <End x-Value> )
 		if (numOfArguments == 3) {
-			String startValue = getArgumentOfCommand(command, 1);
-			String endValue = getArgumentOfCommand(command, 2);
+			String startValue = argumentTranslator.apply(command.getArgument(1));
+			String endValue = argumentTranslator.apply(command.getArgument(2));
 			return "int(" + expression + ",x=" + startValue + ".." + endValue + ")";
 		}
 
 		// if there are four arguments then the command form is Integral( <Function>, <Variable>, <Start Value>, <End Value> )
 		if (numOfArguments == 4) {
-			String varName = getArgumentOfCommand(command, 1);
-			String startValue = getArgumentOfCommand(command, 2);
-			String endValue = getArgumentOfCommand(command, 3);
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			String startValue = argumentTranslator.apply(command.getArgument(2));
+			String endValue = argumentTranslator.apply(command.getArgument(3));
 			return "int(" + expression + "," + varName + "=" + startValue + ".." + endValue + ")";
 		}
 
 		return null;
 	}
 
-	static String translateIntegralBetween(Command command, Map<String, String> fullNameToShortName) {
+	static String translateIntegralBetween(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
-		String upperFunction = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
-		String lowerFunction = getMapleName(getArgumentOfCommand(command, 1), fullNameToShortName);
+		String upperFunction = argumentTranslator.apply(command.getArgument(0));
+		String lowerFunction = argumentTranslator.apply(command.getArgument(1));
 		String expression = "(" + upperFunction + ")-(" + lowerFunction + ")";
 
 		// if there are four arguments then the command form is IntegralBetween( <Function>, <Function>, <Number>, <Number> )
 		if (numOfArguments == 4) {
-			String startValue = getArgumentOfCommand(command, 2);
-			String endValue = getArgumentOfCommand(command, 3);
+			String startValue = argumentTranslator.apply(command.getArgument(2));
+			String endValue = argumentTranslator.apply(command.getArgument(3));
 			return "int(" + expression + ",x=" + startValue + ".." + endValue + ")";
 		}
 
 		// if there are five arguments then the command form is IntegralBetween( <Function>, <Function>, <Variable>, <Number>, <Number> )
 		if (numOfArguments == 5) {
-			String varName = getArgumentOfCommand(command, 2);
-			String startValue = getArgumentOfCommand(command, 3);
-			String endValue = getArgumentOfCommand(command, 4);
+			String varName = argumentTranslator.apply(command.getArgument(2));
+			String startValue = argumentTranslator.apply(command.getArgument(3));
+			String endValue = argumentTranslator.apply(command.getArgument(4));
 			return "int(" + expression + "," + varName + "=" + startValue + ".." + endValue + ")";
 		}
 
 		return null;
 	}
 
-	static String translateLimit(Command command, Map<String, String> fullNameToShortName) {
+	static String translateLimit(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there are two arguments then the command form is Limit( <Expression>, <Value> )
 		if (numOfArguments == 2) {
-			String approachTo = fixPiAppear(getArgumentOfCommand(command, 1));
+			String approachTo = fixPiAppear(argumentTranslator.apply(command.getArgument(1)));
 			return "limit(" + expression + ",x=" + approachTo + ")";
 		}
 
 		// if there are three arguments then the command form is Limit( <Expression>, <Variable>, <Value> )
 		if (numOfArguments == 3) {
-			String varName = getArgumentOfCommand(command, 1);
-			String approachTo = fixPiAppear(getArgumentOfCommand(command, 2));
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			String approachTo = fixPiAppear(argumentTranslator.apply(command.getArgument(2)));
 			return "limit(" + expression + "," + varName + "=" + approachTo + ")";
 		}
 
 		return null;
 	}
 
-	static String translateCurveCartesian(Command command, Map<String, String> fullNameToShortName) {
+	static String translateCurveCartesian(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
 
-		String xExpression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
-		String yExpression = getMapleName(getArgumentOfCommand(command, 1), fullNameToShortName);
-		String varName = getArgumentOfCommand(command, 2);
-		String startValue = fixPiAppear(getArgumentOfCommand(command, 3));
-		String endValue = fixPiAppear(getArgumentOfCommand(command, 4));
+		String xExpression = argumentTranslator.apply(command.getArgument(0));
+		String yExpression = argumentTranslator.apply(command.getArgument(1));
+		String varName = argumentTranslator.apply(command.getArgument(2));
+		String startValue = fixPiAppear(argumentTranslator.apply(command.getArgument(3)));
+		String endValue = fixPiAppear(argumentTranslator.apply(command.getArgument(4)));
 
 		// if there are five arguments then the command form is Curve( <Expression>, <Expression>, <Parameter Variable>, <Start Value>, <End Value> )
 		if (numOfArguments == 5) {
@@ -212,9 +251,10 @@ final class MapleCommandTranslator {
 		return null;
 	}
 
-	static String translateDegree(Command command, Map<String, String> fullNameToShortName) {
+	static String translateDegree(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is Degree( <Polynomial> )
 		if (numOfArguments == 1) {
@@ -223,38 +263,48 @@ final class MapleCommandTranslator {
 
 		// if there are two arguments then the command form is Degree( <Polynomial>, <Variable> )
 		if (numOfArguments == 2) {
-			String varName = getArgumentOfCommand(command, 1);
+			String varName = argumentTranslator.apply(command.getArgument(1));
 			return "degree(" + expression + "," + varName + ")";
 		}
 
 		return null;
 	}
 
-	static String translateDenominator(Command command, Map<String, String> fullNameToShortName) {
-		int numOfArguments = command.getArgumentNumber();
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+	static String translateDenominator(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// the command form is Denominator( <Expression> )
 		return "denom(" + expression + ")";
 	}
 
-	static String translateInvert(Command command) {
-		String expression = getArgumentOfCommand(command, 0).replace(" ", "");
+	static String translateInvert(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+		int numOfArguments = command.getArgumentNumber();
 
-		// the Invert command has two forms with one argument:
-		// Invert( <Matrix> ) and Invert( <Function> )
-		// if the expression has matrix syntax then the command form is Invert( <Matrix> )
-		if (expression.startsWith("{{") && expression.endsWith("}}")) {
-			expression = expression.replace("{", "[").replace("}", "]");
-			return "LinearAlgebra:-MatrixInverse(Matrix(" + expression + "))";
+		if (numOfArguments == 1) {
+			String expression = argumentTranslator.apply(command.getArgument(0)).replace(" ", "");
+
+			// the Invert command has two forms with one argument:
+			// Invert( <Matrix> ) and Invert( <Function> )
+			// if the expression has matrix syntax then the command form is Invert( <Matrix> )
+			if (expression.startsWith("{{") && expression.endsWith("}}")) {
+				expression = expression.replace("{", "[").replace("}", "]");
+				return "LinearAlgebra:-MatrixInverse(Matrix(" + expression + "))";
+			}
+
+			// otherwise the command form is Invert( <Function> )
+			// wrap solve(...) in a list because solve may return several inverse branches
+			return "subs(y=x, [solve(y=" + expression + ", x)])";
 		}
-		// otherwise the command form is Invert( <Function> )
-		return "subs(y=x, solve(y=" + expression + ", x))";
+
+		return null;
 	}
 
-	static String translateNumeric(Command command, Map<String, String> fullNameToShortName) {
+	static String translateNumeric(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is Numeric( <Expression> )
 		if (numOfArguments == 1) {
@@ -264,41 +314,43 @@ final class MapleCommandTranslator {
 
 		// if there are two arguments then the command form is Numeric( <Expression>, <Significant Figures> )
 		if (numOfArguments == 2) {
-			String numOfDigits = getArgumentOfCommand(command, 1);
+			String numOfDigits = argumentTranslator.apply(command.getArgument(1));
 			return "evalf[" + numOfDigits + "](" + expression + ")";
 		}
 
 		return null;
 	}
 
-	static String translateSubstitute(Command command, Map<String, String> fullNameToShortName) {
+	static String translateSubstitute(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getMapleName(getArgumentOfCommand(command, 0), fullNameToShortName);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there are two arguments then the command form is Substitute( <Expression>, <Substitution List> )
 		if (numOfArguments == 2) {
-			String substitutionList = getArgumentOfCommand(command, 1);
+			String substitutionList = argumentTranslator.apply(command.getArgument(1));
 			return  "subs(" + substitutionList + "," + expression + ")";
 		}
 
 		// if there are three arguments and the second argument is not an equation,
 		// then the command form is Substitute( <Expression>, <from>, <to> )
-		if (numOfArguments == 3 && !getArgumentOfCommand(command, 1).contains("=")) {
-			String from = getArgumentOfCommand(command, 1);
-			String to = getArgumentOfCommand(command, 2);
-			return "subs(" + from + "=" + to + "," + expression + ")";
+		String secondArgument = argumentTranslator.apply(command.getArgument(1));
+
+		if (numOfArguments == 3 && !secondArgument.contains("=")) {
+			String to = argumentTranslator.apply(command.getArgument(2));
+			return "subs(" + secondArgument + "=" + to + "," + expression + ")";
 		}
 
 		// if there are three or more arguments and the second argument is an equation,
 		// then the command form is Substitute( <Expression>, <Substitution>, <Substitution>, ... )
-		if (numOfArguments >= 3 && getArgumentOfCommand(command, 1).contains("=")) {
+		if (numOfArguments >= 3 && secondArgument.contains("=")) {
 			StringBuilder substitutionList = new StringBuilder("[");
 
 			for (int j = 1; j < numOfArguments; j++) {
 				if (j > 1) {
 					substitutionList.append(",");
 				}
-				substitutionList.append(getArgumentOfCommand(command, j));
+				substitutionList.append(argumentTranslator.apply(command.getArgument(j)));
 			}
 
 			substitutionList.append("]");
@@ -308,32 +360,36 @@ final class MapleCommandTranslator {
 		return null;
 	}
 
-	static String translateIsPrime(Command command) {
-		String expression = getArgumentOfCommand(command, 0);
+	static String translateIsPrime(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// the command form is IsPrime( <Number> )
 		return  "isprime(" + expression + ")";
 	}
 
-	static String translateModularExponent(Command command) {
-		String base = getArgumentOfCommand(command, 0);
-		String exponent = getArgumentOfCommand(command, 1);
-		String modulus = getArgumentOfCommand(command, 2);
+	static String translateModularExponent(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+		String base = argumentTranslator.apply(command.getArgument(0));
+		String exponent = argumentTranslator.apply(command.getArgument(1));
+		String modulus = argumentTranslator.apply(command.getArgument(2));
 
 		// the command form is ModularExponent( <Number>, <Number>, <Number> )
 		return base + " &^ " + exponent + " mod " + modulus;
 	}
 
-	static String translatePrimeFactors(Command command) {
-		String expression = getArgumentOfCommand(command, 0);
+	static String translatePrimeFactors(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// the command form is PrimeFactors( <Number> )
 		return  "ifactor(" + expression + ")";
 	}
 
-	static String translateLaplace(Command command) {
+	static String translateLaplace(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getArgumentOfCommand(command, 0);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is Laplace( <Function> )
 		if (numOfArguments == 1) {
@@ -347,7 +403,7 @@ final class MapleCommandTranslator {
 
 		// if there are two arguments then the command form is Laplace( <Function>, <Variable> )
 		if (numOfArguments == 2) {
-			String varName = getArgumentOfCommand(command, 1);
+			String varName = argumentTranslator.apply(command.getArgument(1));
 
 			// GeoGebra returns the result using the selected variable name,
 			// so Maple uses a temporary transform variable and then substitutes it back
@@ -357,17 +413,18 @@ final class MapleCommandTranslator {
 
 		// if there are three arguments then the command form is Laplace( <Function>, <Variable>, <Variable> )
 		if (numOfArguments == 3) {
-			String varName = getArgumentOfCommand(command, 1);
-			String newVarName = getArgumentOfCommand(command, 2);
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			String newVarName = argumentTranslator.apply(command.getArgument(2));
 			return "inttrans:-laplace(" + expression + "," + varName + "," + newVarName + ")";
 		}
 
 		return null;
 	}
 
-	static String translateInverseLaplace(Command command) {
+	static String translateInverseLaplace(Command command,
+			Function<ExpressionNode, String> argumentTranslator) {
 		int numOfArguments = command.getArgumentNumber();
-		String expression = getArgumentOfCommand(command, 0);
+		String expression = argumentTranslator.apply(command.getArgument(0));
 
 		// if there is only one argument then the command form is InverseLaplace( <Function> )
 		if (numOfArguments == 1) {
@@ -381,7 +438,7 @@ final class MapleCommandTranslator {
 
 		// if there are two arguments then the command form is InverseLaplace( <Function>, <Variable> )
 		if (numOfArguments == 2) {
-			String varName = getArgumentOfCommand(command, 1);
+			String varName = argumentTranslator.apply(command.getArgument(1));
 
 			// GeoGebra returns the result using the selected variable name,
 			// so Maple uses a temporary result variable and then substitutes it back
@@ -391,8 +448,8 @@ final class MapleCommandTranslator {
 
 		// if there are three arguments then the command form is InverseLaplace( <Function>, <Variable>, <Variable> )
 		if (numOfArguments == 3) {
-			String varName = getArgumentOfCommand(command, 1);
-			String newVarName = getArgumentOfCommand(command, 2);
+			String varName = argumentTranslator.apply(command.getArgument(1));
+			String newVarName = argumentTranslator.apply(command.getArgument(2));
 			return "inttrans:-invlaplace(" + expression + "," + varName + "," + newVarName + ")";
 		}
 
@@ -409,14 +466,7 @@ final class MapleCommandTranslator {
 		return "t";
 	}
 
-
-
-	private static String getArgumentOfCommand(Command command, int argumentIndex) {
-		return command.getArgument(argumentIndex)
-				.getCASstring(StringTemplate.casCopyTemplate, false);
-	}
-
-	private static String getMapleName(String expression,
+	public static String getMapleName(String expression,
 			Map<String, String> fullNameToShortName) {
 		String shortName = fullNameToShortName.get(expression);
 		return shortName == null ? expression : shortName;
@@ -427,5 +477,14 @@ final class MapleCommandTranslator {
 			toFix = toFix.replace("pi" , "Pi");
 		}
 		return toFix;
+	}
+
+	private static boolean isIntegerExpression(String expression) {
+		try {
+			Long.parseLong(expression);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Move Maple command dispatch into a shared translateMapleCommand method and use translateMapleArgument to translate command arguments recursively. This allows supported commands to be nested inside each other during Maple export.

Example of nested GeoGebra commands and the generated Maple output:
<img width="1464" height="375" alt="צילום מסך 2026-05-18 ב-11 23 54" src="https://github.com/user-attachments/assets/28214bf9-b9ad-437d-8297-0370c9903c54" />
<img width="929" height="116" alt="צילום מסך 2026-05-18 ב-11 25 38" src="https://github.com/user-attachments/assets/d51d337a-0afd-49ca-834a-d0466a1a1ca0" />

